### PR TITLE
execAndSuppress: log on stderr if the command fails

### DIFF
--- a/pkg/daemon/common.go
+++ b/pkg/daemon/common.go
@@ -4,9 +4,11 @@
 package daemon
 
 import (
+	"bytes"
 	"errors"
-	"github.com/sirupsen/logrus"
 	"os/exec"
+
+	"github.com/sirupsen/logrus"
 )
 
 func execCmd(args []string, log *logrus.Logger) (string, error) {
@@ -28,12 +30,16 @@ func execAndSuppress(args []string, log *logrus.Logger, suppressError func(e err
 
 	log.WithField("cmd", cmd).Info("executing command")
 
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil {
 		if suppressError(err) {
 			log.WithField("cmd", args).WithError(err).Info("ignoring error")
 		} else {
-			log.WithField("cmd", args).WithField("output", string(out)).WithError(err).Error("failed to execute command")
+			log.WithField("cmd", args).WithField("output", string(out)).
+				WithField("stderr", stderr.String()).
+				WithError(err).Error("failed to execute command")
 			return string(out), err
 		}
 	}


### PR DESCRIPTION
Standard error might contain useful information about the failing command. This commit adds the content of the `stderr` to the logs.