### PR TITLE
Add support for OpenShift management workload partitioning

### DIFF
--- a/assets/100-labeler.yaml
+++ b/assets/100-labeler.yaml
@@ -96,6 +96,8 @@ data:
           app: accelerator-discovery
       template:
         metadata:
+          annotations:
+            target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
           labels:
             app: accelerator-discovery
           name: accelerator-discovery

--- a/assets/200-device-plugin.yaml
+++ b/assets/200-device-plugin.yaml
@@ -141,6 +141,8 @@ data:
           app: sriov-device-plugin-daemonset
       template:
         metadata:
+          annotations:
+            target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
           labels:
             app: sriov-device-plugin-daemonset
         spec:

--- a/assets/300-daemon.yaml
+++ b/assets/300-daemon.yaml
@@ -169,6 +169,7 @@ data:
           # a failure.  This annotation works in tandem with the toleration below.
           annotations:
             scheduler.alpha.kubernetes.io/critical-pod: ""
+            target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
           labels:
             app: sriov-fec-daemonset
         spec:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,6 +24,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         control-plane: controller-manager
     spec:

--- a/spec/openshift-deployment.md
+++ b/spec/openshift-deployment.md
@@ -21,6 +21,12 @@ Create the project:
 ```shell
 [user@ctrl1 /home]# oc new-project vran-acceleration-operators
 ```
+
+**Optional:** Annotate the project to enable management workload partitioning:
+```
+oc annotate namespace vran-acceleration-operators workload.openshift.io/allowed=management
+```
+
 Execute following commands on cluster:
 
 Create an operator group and the subscriptions (all the commands are run in the `vran-acceleration-operators` namespace):


### PR DESCRIPTION
Add annotations for OpenShift management workload partitioning. Administrators can opt into the feature by annotating the namespace with workload.openshift.io/allowed: management. Otherwise, these annotations will have no effect.

For further details, see:
* https://andreaskaris.github.io/blog/openshift/cpu-isolation-in-openshift/
* https://docs.openshift.com/container-platform/4.14/scalability_and_performance/enabling-workload-partitioning.html
* https://github.com/openshift/enhancements/blob/master/enhancements/workload-partitioning/management-workload-partitioning.md#high-level-end-to-end-workflow
* https://github.com/openshift/enhancements/blob/master/enhancements/workload-partitioning/wide-availability-workload-partitioning.md

In earlier versions of OpenShift (notably 4.14), management workload partitioning does not support pods with both limits and requests set: https://github.com/openshift/kubernetes/blob/fd36fb9acf9a99270f4fca3f5817fd52c8bc58b4/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission.go#L258
This only changed very recently (for not yet released OpenShift 4.16) with: https://github.com/openshift/kubernetes/pull/1902
Therefore, when running on these older versions, the operator pod itself will still be skipped for management workload partitioning:
```
     workload.openshift.io/warning: skip pod CPUs requests modifications because
        pod container has both CPU limit and request
```